### PR TITLE
XCB window is mapped and flushed upon window creation

### DIFF
--- a/Project/Common/OperatingSystem.cpp
+++ b/Project/Common/OperatingSystem.cpp
@@ -183,6 +183,9 @@ namespace ApiWithoutSecrets {
         strlen( title ),
         title );
 
+      xcb_map_window( Parameters.Connection, Parameters.Handle );
+      xcb_flush( Parameters.Connection );
+
       return true;
     }
 


### PR DESCRIPTION
I had an issue when running samples 2 and beyond on Gentoo GNU/Linux with the GNOME 3 desktop.  This seems to be specific to XCB.  Mapping the window then flushing the connection appears to have resolved the issue.
