### PR TITLE
fix window creation with XCB and XLIB

### DIFF
--- a/Project/Common/OperatingSystem.cpp
+++ b/Project/Common/OperatingSystem.cpp
@@ -182,6 +182,8 @@ namespace ApiWithoutSecrets {
         XCB_CW_BACK_PIXEL | XCB_CW_EVENT_MASK,
         value_list );
 
+      xcb_flush( Parameters.Connection );
+
       xcb_change_property(
         Parameters.Connection,
         XCB_PROP_MODE_REPLACE,
@@ -295,6 +297,7 @@ namespace ApiWithoutSecrets {
         BlackPixel( Parameters.DisplayPtr, default_screen ),
         WhitePixel( Parameters.DisplayPtr, default_screen ) );
 
+      // XSync( Parameters.DisplayPtr, false );
       XSetStandardProperties( Parameters.DisplayPtr, Parameters.Handle, title, title, None, nullptr, 0, nullptr );
       XSelectInput( Parameters.DisplayPtr, Parameters.Handle, ExposureMask | KeyPressMask | StructureNotifyMask );
 


### PR DESCRIPTION
Prevents accessing the window before it is ready, causing this error:

    X Error of failed request:  BadDrawable (invalid Pixmap or Window parameter)
      Major opcode of failed request:  14 (X_GetGeometry)
      Resource id in failed request:  0x5800009
      Serial number of failed request:  42
      Current serial number in output stream:  42

Taken from Stackoverflow: http://stackoverflow.com/questions/36486036/vulkan-on-x11-vkgetphysicaldevicesurfacecapabilitieskhr-error (both answers for the respective platform).