### PR TITLE
Use the parameter of the image handle to allocate memory.

### DIFF
--- a/Project/Tutorial06/Tutorial06.cpp
+++ b/Project/Tutorial06/Tutorial06.cpp
@@ -242,7 +242,7 @@ namespace ApiWithoutSecrets {
 
   bool Tutorial06::AllocateImageMemory( VkImage image, VkMemoryPropertyFlagBits property, VkDeviceMemory *memory ) {
     VkMemoryRequirements image_memory_requirements;
-    vkGetImageMemoryRequirements( GetDevice(), Vulkan.Image.Handle, &image_memory_requirements );
+    vkGetImageMemoryRequirements( GetDevice(), image, &image_memory_requirements );
 
     VkPhysicalDeviceMemoryProperties memory_properties;
     vkGetPhysicalDeviceMemoryProperties( GetPhysicalDevice(), &memory_properties );

--- a/Project/Tutorial07/Tutorial07.cpp
+++ b/Project/Tutorial07/Tutorial07.cpp
@@ -242,7 +242,7 @@ namespace ApiWithoutSecrets {
 
   bool Tutorial07::AllocateImageMemory( VkImage image, VkMemoryPropertyFlagBits property, VkDeviceMemory *memory ) {
     VkMemoryRequirements image_memory_requirements;
-    vkGetImageMemoryRequirements( GetDevice(), Vulkan.Image.Handle, &image_memory_requirements );
+    vkGetImageMemoryRequirements( GetDevice(), image, &image_memory_requirements );
 
     VkPhysicalDeviceMemoryProperties memory_properties;
     vkGetPhysicalDeviceMemoryProperties( GetPhysicalDevice(), &memory_properties );


### PR DESCRIPTION
The original code will use Vulkan.Image.Handle to query the requirement of
the image to be allocated memory, which is unreasonable, since the handle
for the image has been given as the parameter "image" already. When reuse
this function to create other images, the program would crash in the
driver side for this reason.