### PR TITLE
Move to VS2017

### DIFF
--- a/Project/build.bat
+++ b/Project/build.bat
@@ -21,7 +21,7 @@ echo Preparing 'IntroductionToVulkan' solution...
 mkdir build
 cd build
 
-cmake.exe .. -DUSE_PLATFORM=VK_USE_PLATFORM_WIN32_KHR -G "Visual Studio 12 2013 Win64"
+cmake.exe .. -DUSE_PLATFORM=VK_USE_PLATFORM_WIN32_KHR -G "Visual Studio 15 2017 Win64"
 
 start "" "IntroductionToVulkan.sln"
 


### PR DESCRIPTION
VS2017 community is the most widely used (because it's free), so deprecate
VS2013 and move to VS2017.